### PR TITLE
BankAccountTypes.php does not comply with psr-0 autoloading standard

### DIFF
--- a/src/Genesis/API/Constants/BankAccountTypes.php
+++ b/src/Genesis/API/Constants/BankAccountTypes.php
@@ -21,7 +21,7 @@
  * @license     http://opensource.org/licenses/MIT The MIT License
  */
 
-namespace Genesis\Api\Constants;
+namespace Genesis\API\Constants;
 
 /**
  * Class BankAccountTypes


### PR DESCRIPTION
* fix namespace

Fixes eMerchantPay/genesis_client_integrations#number  It will not autoload anymore in Composer v2.0
