### PR TITLE
fix: correct typo in .env file (lover -> lower)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installation
 composer.phar require genesisgateway/genesis_php
 ```
 
-Note: If you want to use the package with PHP version lover than 7.4, you can use 
+Note: If you want to use the package with PHP version lower than 7.4, you can use 
 
 ```sh
 composer.phar require genesisgateway/genesis_php --update-no-dev


### PR DESCRIPTION
- Corrected a typo in the readme.Md file, changing "lover" to "lower"
